### PR TITLE
Use new Minicart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.1.0] - 2020-01-10
+
 ## [3.16.2] - 2019-10-17
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -47,7 +47,10 @@
     "vtex.product-specification-badges": "0.x",
     "vtex.product-review-interfaces": "1.x",
     "vtex.telemarketing": "2.x",
-    "vtex.order-placed": "1.x"
+    "vtex.order-placed": "1.x",
+    "vtex.checkout-summary": "0.x",
+    "vtex.product-list": "0.x",
+    "vtex.add-to-cart-button": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -44,7 +44,10 @@
     "vtex.product-customizer": "2.x",
     "vtex.stack-layout": "0.x",
     "vtex.sandbox": "0.x",
-    "vtex.product-specification-badges": "0.x"
+    "vtex.product-specification-badges": "0.x",
+    "vtex.product-review-interfaces": "1.x",
+    "vtex.telemarketing": "2.x",
+    "vtex.order-placed": "1.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "gc-bba7553",
   "name": "mj-bricks",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "title": "MJ Bricks Theme",
   "builders": {
     "styles": "1.x",

--- a/store/blocks.jsonc
+++ b/store/blocks.jsonc
@@ -40,7 +40,7 @@
       "product-summary-space",
       "product-summary-price",
       "product-identifier.summary",
-      "product-summary-buy-button"
+      "add-to-cart-button"
     ]
   },
 

--- a/store/blocks/header/header.json
+++ b/store/blocks/header/header.json
@@ -176,6 +176,14 @@
       "showDeliveryTotal": false
     }
   },
+  "minicart-empty-state": {
+    "children": ["rich-text#empty-state"]
+  },
+  "rich-text#empty-state": {
+    "props": {
+      "text": "Seu carrinho está vazio!"
+    }
+  },
 
   "logo#mobile": {
     "props": {

--- a/store/blocks/header/header.json
+++ b/store/blocks/header/header.json
@@ -75,7 +75,7 @@
       "search-bar",
       "locale-switcher",
       "login",
-      "minicart"
+      "minicart.v2"
     ],
     "props": {
       "sticky": true,
@@ -85,7 +85,7 @@
 
   "search-bar#mobile": {
     "props": {
-      "compactMode": false 
+      "compactMode": false
     }
   },
 
@@ -105,23 +105,6 @@
     }
   },
 
-  "minicart": {
-    "blocks": [
-      "product-summary"
-    ],
-    "props": {
-      "type": "popup",
-      "showRemoveButton": true,
-      "showDiscount": true,
-      "showSku": true,
-      "labelMiniCartEmpty": "",
-      "labelButtonFinishShopping": "Go to checkout",
-      "enableQuantitySelector": true,
-      "maxQuantity": 10,
-      "labelClasses": "gray"
-    }
-  },
-
   "header-layout.mobile": {
     "children": [
       "header-row#1-mobile",
@@ -134,7 +117,7 @@
       "logo.auto-image",
       "header-spacer",
       "login#mobile",
-      "minicart"
+      "minicart.v2"
     ],
     "props": {
       "sticky": true,
@@ -148,7 +131,7 @@
     ]
   },
 
-  
+
   "drawer": {
     "children": [
       "category-menu"
@@ -163,6 +146,34 @@
     ],
     "props": {
       "orientation": "vertical"
+    }
+  },
+
+  "minicart.v2": {
+    "children": ["minicart-base-content"]
+  },
+  "minicart-base-content": {
+    "blocks": ["minicart-product-list", "minicart-summary", "minicart-empty-state"]
+  },
+
+  "minicart-product-list": {
+    "blocks": ["product-list"]
+  },
+
+  "minicart-summary": {
+    "blocks": ["checkout-summary.compact"]
+  },
+
+  "checkout-summary.compact": {
+    "children": ["summary-totalizers#minicart"],
+    "props": {
+      "totalizersToShow": ["Items", "Discounts"]
+    }
+  },
+  "summary-totalizers#minicart": {
+    "props": {
+      "showTotal": true,
+      "showDeliveryTotal": false
     }
   },
 

--- a/store/blocks/product-list.json
+++ b/store/blocks/product-list.json
@@ -1,0 +1,57 @@
+{
+  "product-list": {
+    "blocks": [
+      "product-list-content-desktop",
+      "product-list-content-mobile"
+    ]
+  },
+  "product-list-content-mobile": {
+    "children": ["flex-layout.row#list-row.mobile"]
+  },
+  "flex-layout.row#list-row.mobile": {
+    "children": [
+      "flex-layout.col#image.mobile",
+      "flex-layout.col#main-container.mobile"
+    ],
+    "props": {
+      "fullWidth": true,
+      "paddingBottom": "6",
+      "paddingTop": "5",
+      "colSizing": "auto",
+      "preserveLayoutOnMobile": "true"
+    }
+  },
+  "flex-layout.col#main-container.mobile": {
+    "children": [
+      "flex-layout.row#top.mobile",
+      "flex-layout.row#quantity-selector.mobile",
+      "flex-layout.row#unit-price.mobile",
+      "flex-layout.row#price.mobile",
+      "flex-layout.row#message.mobile"
+    ],
+    "props": {
+      "width": "grow"
+    }
+  },
+  "flex-layout.row#top.mobile": {
+    "children": [
+      "flex-layout.col#product-description",
+      "flex-layout.col#remove-button.mobile"
+    ],
+    "props": {
+      "colSizing": "auto",
+      "preserveLayoutOnMobile": "true"
+    }
+  },
+  "flex-layout.col#product-description": {
+    "children": [
+      "flex-layout.row#product-name",
+      "flex-layout.row#product-variations"
+    ],
+    "props": {
+      "marginBottom": "5",
+      "width": "grow",
+      "preventVerticalStretch": "true"
+    }
+  }
+}

--- a/store/blocks/product.json
+++ b/store/blocks/product.json
@@ -63,7 +63,7 @@
       "rowGap": 0
     },
     "children": [
-      "product-name",
+      "vtex.store-components:product-name",
       "product-rating-summary",
       "product-price#product-details",
       "product-separator",
@@ -79,11 +79,12 @@
     ]
   },
 
-  "buy-button": {
+  "add-to-cart-button": {
     "props": {
-      "isOneClickBuy": true
+      "isOneClickBuy": true,
+      "customOneClickBuyLink": "/cart"
     }
-  }, 
+  },
 
   "product-price#product-details": {
     "props": {
@@ -97,7 +98,7 @@
       "marginTop": 4,
       "marginBottom": 7
     },
-    "children": ["buy-button"]
+    "children": ["add-to-cart-button"]
   },
 
   "share#default": {


### PR DESCRIPTION
We recently started using the new Cart in some GoCommerce stores (MJ Bricks being one of them), but it doesn't work well with the current Minicart. Since both components use different data sources, the UI becomes inconsistent if the user interacts with the product list in the `/cart` page.

This PR fixes this issue by replacing the Minicart with a newer version, that uses the same architecture that the new Cart uses. This ensures both the product list and the Minicart display always the same information.

Differently from https://github.com/vtex-gocommerce/theme-madinejeans/pull/1, this PR did not require a change in the product page because the theme was already using the same structure as the `store-theme`.

Test workspace: https://minicart--gc-bba7553.mygocommerce.com/

| New | ![image](https://user-images.githubusercontent.com/8902498/72174462-93822380-33b8-11ea-99de-d3213ae2efea.png) |
|------|------------------|
| **Old** | ![image](https://user-images.githubusercontent.com/8902498/72174410-764d5500-33b8-11ea-92dc-693249a58d16.png) |
